### PR TITLE
Fixed an example highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ character can be repeated. For example the regular expression `[0-9]{2,3}` means
 characters in the range of 0 to 9).
 
 <pre>
-"[0-9]{2}" => The number was 9.<a href="#learn-regex"><strong>999</strong></a>7 but we rounded it off to <a href="#learn-regex"><strong>10</strong></a>.0.
+"[0-9]{2}" => The number was 9.<a href="#learn-regex"><strong>99</strong></a><a href="#learn-regex"><strong>97</strong></a> but we rounded it off to <a href="#learn-regex"><strong>10</strong></a>.0.
 </pre>
 
 We can leave out the second number. For example the regular expression `[0-9]{2,}` means: Match 2 or more digits. If we also remove 


### PR DESCRIPTION
[0-9]{2} matches twice in the "9.9997"

In the current version it highlights 3 numbers