### PR TITLE
Username update

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ line. And because of `m` flag now regular expression engine matches pattern at t
 * *US Phone Number*: `^+?[\d\s]{3,}$`
 * *US Phone with code*: `^+?[\d\s]+(?[\d\s]{10,}$`
 * *Integers*: `^-?\d+$`
-* *Username*: `^[\w\d_.]{4,16}$`
+* *Username*: `^[\w.]{4,16}$`
 * *Alpha-numeric characters*: `^[a-zA-Z0-9]*$`
 * *Alpha-numeric characters with spaces*: `^[a-zA-Z0-9 ]*$`
 * *Password*: `^(?=^.{6,}$)((?=.*[A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z]))^.*$`


### PR DESCRIPTION
As pointed out by @jdp - `\d` and `_` are a subset of `\w`.

Maybe worth mentioning that most places don't allow usernames to start with a number, underscore, or dot.

Even more generally speaking, these are nice toy/model illustrations, but maybe it's worth pointing out that while fun for practice, maybe regex isn't the best way to validate some of these things.