### PR TITLE
deleted the bonus from table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ contains uppercase letter and also it is too short.
   - [Case Insensitive](#51-case-insensitive)
   - [Global search](#52-global-search)
   - [Multiline](#53-multiline)
-- [Bonus](#bonus)
 
 ## 1. Basic Matchers
 


### PR DESCRIPTION
As you now you have removed the bonus section, which contained the examples, the bonus tag should be removed from the table of contents also.